### PR TITLE
Remove unused `libunwind_installer#libunwind_tar_gz method`

### DIFF
--- a/lib/buildpack/compile/libunwind_installer.rb
+++ b/lib/buildpack/compile/libunwind_installer.rb
@@ -29,10 +29,6 @@ module AspNetCoreBuildpack
       @shell.exec("mkdir -p #{dest_dir}; tar xzf /tmp/#{dependency_name} -C #{dest_dir}", out)
     end
 
-    def libunwind_tar_gz(out)
-      @shell.exec("#{buildpack_root}/compile-extensions/bin/translate_dependency_url #{dependency_name}", out)
-    end
-
     def version
       VERSION
     end

--- a/spec/buildpack/compile/libunwind_installer_spec.rb
+++ b/spec/buildpack/compile/libunwind_installer_spec.rb
@@ -32,28 +32,6 @@ describe AspNetCoreBuildpack::LibunwindInstaller do
     end
   end
 
-  describe '#libunwind_tar_gz' do
-    context 'when binary present in dependencies dir' do
-      it 'uses local binary' do
-        begin
-          dependencies = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'dependencies'))
-          FileUtils.mkdir_p dependencies
-          expect(out).to receive(:print).with(%r{file:///})
-          subject.libunwind_tar_gz(out)
-        ensure
-          FileUtils.rm_rf(dependencies) if File.exist? dependencies
-        end
-      end
-    end
-
-    context 'when binary not present in dependencies dir' do
-      it 'uses remote binary' do
-        expect(out).to receive(:print).with(%r{https://})
-        subject.libunwind_tar_gz(out)
-      end
-    end
-  end
-
   describe '#extract' do
     it 'downloads file with compile-extensions' do
       allow(shell).to receive(:exec).and_return(0)


### PR DESCRIPTION
- As discussed at https://github.com/cloudfoundry-community/dotnet-core-buildpack/pull/56#issuecomment-222251372