### PR TITLE
Add Preview2 dependency

### DIFF
--- a/cf_spec/fixtures/asp_mvc_api_app/global.json
+++ b/cf_spec/fixtures/asp_mvc_api_app/global.json
@@ -1,0 +1,6 @@
+{
+  "projects": [ "src", "test" ],
+  "sdk": {
+    "version": "1.0.0-preview1-002702"
+  }
+}

--- a/cf_spec/fixtures/asp_mvc_app/global.json
+++ b/cf_spec/fixtures/asp_mvc_app/global.json
@@ -1,0 +1,6 @@
+{
+  "projects": [ "src", "test" ],
+  "sdk": {
+    "version": "1.0.0-preview1-002702"
+  }
+}

--- a/cf_spec/fixtures/asp_web_app/global.json
+++ b/cf_spec/fixtures/asp_web_app/global.json
@@ -1,0 +1,6 @@
+{
+  "projects": [ "src", "test" ],
+  "sdk": {
+    "version": "1.0.0-preview1-002702"
+  }
+}

--- a/cf_spec/integration/deploy_dotnetcore_app_spec.rb
+++ b/cf_spec/integration/deploy_dotnetcore_app_spec.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH << 'cf_spec'
 require 'spec_helper'
 
-describe 'CF Asp.Net5 Buildpack' do
+describe 'CF ASP.NET Core Buildpack' do
   subject(:app) { Machete.deploy_app(app_name) }
   let(:browser) { Machete::Browser.new(app) }
 

--- a/lib/buildpack/compile/dotnet_installer.rb
+++ b/lib/buildpack/compile/dotnet_installer.rb
@@ -19,13 +19,12 @@ require_relative 'dotnet_version'
 
 module AspNetCoreBuildpack
   class DotnetInstaller
-    VERSION = '1.0.0-preview1-002702'.freeze
-
     def initialize(shell)
       @shell = shell
     end
 
     def install(dir, out)
+      @version = DotnetVersion.new.version(dir, out)
       dest_dir = "#{dir}/.dotnet"
 
       out.print("dotnet version: #{version}")
@@ -41,10 +40,6 @@ module AspNetCoreBuildpack
       true
     end
 
-    def version
-      VERSION
-    end
-
     private
 
     def buildpack_root
@@ -55,5 +50,7 @@ module AspNetCoreBuildpack
     def dependency_name
       "dotnet-dev-ubuntu-x64.#{version}.tar.gz"
     end
+
+    attr_reader :version
   end
 end

--- a/lib/buildpack/compile/dotnet_version.rb
+++ b/lib/buildpack/compile/dotnet_version.rb
@@ -19,7 +19,7 @@ require 'json'
 module AspNetCoreBuildpack
   class DotnetVersion
     DOTNET_VERSION_FILE_NAME = 'global.json'.freeze
-    DEFAULT_DOTNET_VERSION = 'latest'.freeze
+    DEFAULT_DOTNET_VERSION = '1.0.0-preview2-003121'.freeze
 
     def version(dir, out)
       dotnet_version = DEFAULT_DOTNET_VERSION

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,23 +5,29 @@ url_to_dependency_map:
   - match: libunwind-(.*)-(\d+\.\d+)
     name: libunwind
     version: $2
-  - match: dotnet-dev-ubuntu-x64\.([\w\.-]+)\.tar\.gz
+  - match: dotnet-dev-ubuntu-x64\.(.*)\.tar\.gz
     name: dotnet
-    version: 1.0.0-preview1-002702
+    version: $1
 
 dependencies:
   - name: libunwind
     version: 1.1
     cf_stacks:
       - cflinuxfs2
-    uri: https://github.com/cloudfoundry-community/asp.net5-buildpack/releases/download/v0.7/libunwind-cflinuxfs2-1.1.tar.gz
+    uri: https://github.com/cloudfoundry-community/dotnet-core-buildpack/releases/download/v0.7/libunwind-cflinuxfs2-1.1.tar.gz
     md5: b76452a8a2400f3cfdf189761e8be97e
   - name: dotnet
     version: 1.0.0-preview1-002702
     cf_stacks:
       - cflinuxfs2
-    uri: https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/1.0.0-preview1-002702/dotnet-dev-ubuntu-x64.1.0.0-preview1-002702.tar.gz
-    md5: 38b8ee1062cd3b967237309707fb4b04
+    uri: https://go.microsoft.com/fwlink/?LinkID=798405
+    md5: 44d1dcae69a11976cfc6facc83b3aa49
+  - name: dotnet
+    version: 1.0.0-preview2-003121
+    cf_stacks:
+      - cflinuxfs2
+    uri: https://go.microsoft.com/fwlink/?LinkID=809129
+    md5: 301bf94c4253c6e07826dd6e1d79821f
 
 exclude_files:
   - .git/

--- a/spec/buildpack/compile/dotnet_installer_spec.rb
+++ b/spec/buildpack/compile/dotnet_installer_spec.rb
@@ -23,12 +23,6 @@ describe AspNetCoreBuildpack::DotnetInstaller do
   let(:out) { double(:out) }
   subject(:installer) { AspNetCoreBuildpack::DotnetInstaller.new(shell) }
 
-  describe '#version' do
-    it 'has a default version' do
-      expect(subject.version).to eq('1.0.0-preview1-002702')
-    end
-  end
-
   describe '#install' do
     it 'downloads file with compile-extensions' do
       allow(shell).to receive(:exec).and_return(0)

--- a/spec/buildpack/compile/dotnet_version_spec.rb
+++ b/spec/buildpack/compile/dotnet_version_spec.rb
@@ -21,11 +21,12 @@ require_relative '../../../lib/buildpack.rb'
 describe AspNetCoreBuildpack::DotnetVersion do
   let(:out) { double(:out) }
   let(:dir) { Dir.mktmpdir }
+  let(:latest_version) { '1.0.0-preview2-003121'.freeze }
 
   describe '#version' do
     context 'global.json does not exist' do
       it 'resolves to the latest version' do
-        expect(subject.version(dir, out)).to eq('latest')
+        expect(subject.version(dir, out)).to eq(latest_version)
       end
     end
 
@@ -59,7 +60,7 @@ describe AspNetCoreBuildpack::DotnetVersion do
 
       it 'warns and resolves to the latest version' do
         expect(out).to receive(:warn).with("File #{dir}/global.json is not valid JSON")
-        expect(subject.version(dir, out)).to eq('latest')
+        expect(subject.version(dir, out)).to eq(latest_version)
       end
     end
 
@@ -70,7 +71,7 @@ describe AspNetCoreBuildpack::DotnetVersion do
       end
 
       it 'resolves to the latest version' do
-        expect(subject.version(dir, out)).to eq('latest')
+        expect(subject.version(dir, out)).to eq(latest_version)
       end
     end
   end


### PR DESCRIPTION
1. Add .NET CLI 1.0.0-preview2-003121 dependency to the manifest and change 1.0.0-preview1-002702's download link to use a CDN for improved speed/reliability.
1. Update integration test fixtures to specify a runtime version in global.json.

