### PR TITLE
Make detect more specific

### DIFF
--- a/lib/buildpack/detect/detecter.rb
+++ b/lib/buildpack/detect/detecter.rb
@@ -17,7 +17,12 @@
 module AspNetCoreBuildpack
   class Detecter
     def detect(dir)
-      fromsource = !Dir.glob(File.join(dir, '**', 'project.json')).empty?
+      fromsource = false
+      arr = Dir.glob(File.join(dir, '**', 'project.json')).map { |file| File.dirname(file) }
+      arr.each do |directory|
+        fromsource = !Dir.glob(File.join(directory, '*.cs')).empty? unless fromsource
+        fromsource = !Dir.glob(File.join(directory, '**', '*.cs')).empty? unless fromsource
+      end
       frompublish = !Dir.glob(File.join(dir, '*.runtimeconfig.json')).empty?
       fromsource || frompublish
     end

--- a/spec/buildpack/detect/detect_spec.rb
+++ b/spec/buildpack/detect/detect_spec.rb
@@ -43,8 +43,31 @@ describe AspNetCoreBuildpack::Detecter do
         File.open(File.join(dir, 'project.json'), 'w') { |f| f.write('a') }
       end
 
-      it 'returns true' do
-        expect(subject.detect(dir)).to be_truthy
+      context 'and .cs file exists in the same directory' do
+        before do
+          File.open(File.join(dir, 'Program.cs'), 'w') { |f| f.write('a') }
+        end
+
+        it 'returns true' do
+          expect(subject.detect(dir)).to be_truthy
+        end
+      end
+
+      context 'and .cs file exists in a sub directory' do
+        before do
+          FileUtils.mkdir_p(File.join(dir, 'sub'))
+          File.open(File.join(dir, 'sub', 'Program.cs'), 'w') { |f| f.write('a') }
+        end
+
+        it 'returns true' do
+          expect(subject.detect(dir)).to be_truthy
+        end
+      end
+
+      context 'but no .cs file exists in the directory or sub directories' do
+        it 'returns false' do
+          expect(subject.detect(dir)).not_to be_truthy
+        end
       end
     end
 
@@ -54,8 +77,31 @@ describe AspNetCoreBuildpack::Detecter do
         File.open(File.join(dir, 'src', 'proj', 'project.json'), 'w') { |f| f.write('a') }
       end
 
-      it 'returns true' do
-        expect(subject.detect(dir)).to be_truthy
+      context 'and .cs file exists in the same directory' do
+        before do
+          File.open(File.join(dir, 'src', 'proj', 'Program.cs'), 'w') { |f| f.write('a') }
+        end
+
+        it 'returns true' do
+          expect(subject.detect(dir)).to be_truthy
+        end
+      end
+
+      context 'and .cs file exists in a sub directory' do
+        before do
+          FileUtils.mkdir_p(File.join(dir, 'src', 'proj', 'sub'))
+          File.open(File.join(dir, 'src', 'proj', 'sub', 'Program.cs'), 'w') { |f| f.write('a') }
+        end
+
+        it 'returns true' do
+          expect(subject.detect(dir)).to be_truthy
+        end
+      end
+
+      context 'but no .cs file exists in the directory or sub directories' do
+        it 'returns false' do
+          expect(subject.detect(dir)).not_to be_truthy
+        end
       end
     end
   end


### PR DESCRIPTION
Detect method will now look for a directory which contains both a `project.json` file and a `*.cs` file either in that same directory or in a nested sub-directory.  This will prevent the buildpack from incorrectly detecting other application types which also contain a `project.json` file nested in the file structure.