### PR TITLE
Change scripts keys which trigger Node.js install

### DIFF
--- a/cf_spec/unit/buildpack/compile/installers/bower_installer_spec.rb
+++ b/cf_spec/unit/buildpack/compile/installers/bower_installer_spec.rb
@@ -85,7 +85,7 @@ describe AspNetCoreBuildpack::BowerInstaller do
     context 'app is not self-contained' do
       before do
         FileUtils.mkdir_p(File.join(dir, 'src', 'project1'))
-        File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "prebuild": "bower install" }}') }
+        File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "precompile": "bower install" }}') }
       end
 
       it 'returns true when scripts section exists' do

--- a/cf_spec/unit/buildpack/compile/installers/nodejs_installer_spec.rb
+++ b/cf_spec/unit/buildpack/compile/installers/nodejs_installer_spec.rb
@@ -74,7 +74,7 @@ describe AspNetCoreBuildpack::NodeJsInstaller do
         context 'has both npm and bower commands' do
           before do
             FileUtils.mkdir_p(File.join(dir, 'src', 'project1'))
-            File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "prebuild":["npm install", "bower install"] }}') }
+            File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "precompile":["npm install", "bower install"] }}') }
           end
 
           it 'returns true' do
@@ -84,7 +84,7 @@ describe AspNetCoreBuildpack::NodeJsInstaller do
 
         context 'has only npm command' do
           before do
-            File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "prebuild": "npm install" }}') }
+            File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "precompile": "npm install" }}') }
           end
 
           it 'returns true' do
@@ -94,7 +94,7 @@ describe AspNetCoreBuildpack::NodeJsInstaller do
 
         context 'has only bower command' do
           before do
-            File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "prebuild": "bower install" }}') }
+            File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "precompile": "bower install" }}') }
           end
 
           it 'returns true' do
@@ -104,7 +104,7 @@ describe AspNetCoreBuildpack::NodeJsInstaller do
 
         context 'has no bower or npm command' do
           before do
-            File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "prebuild": "minify js" }}') }
+            File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "precompile": "minify js" }}') }
           end
 
           it 'returns false' do

--- a/cf_spec/unit/buildpack/compile/scripts_parser_spec.rb
+++ b/cf_spec/unit/buildpack/compile/scripts_parser_spec.rb
@@ -28,63 +28,63 @@ describe AspNetCoreBuildpack::ScriptsParser do
     context 'scripts section exists in project.json' do
       before do
         FileUtils.mkdir_p(File.join(dir, 'src', 'project1'))
-        File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "prebuild":["npm install", "bower install"] }}') }
+        File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "precompile":["npm install", "bower install"] }}') }
       end
 
       it 'returns a json object representing the scripts section' do
-        scripts_section = { 'prebuild' => ['npm install', 'bower install'] }
+        scripts_section = { 'precompile' => ['npm install', 'bower install'] }
         expect(subject.get_scripts_section(File.join(dir, 'src', 'project1', 'project.json'))).to eq(scripts_section)
       end
     end
   end
 
   describe '#key_contains_command' do
-    let(:scripts_array) { { 'prebuild' => ['another command', 'npm install'] } }
-    let(:scripts_string) { { 'prebuild' => 'npm install' } }
+    let(:scripts_array) { { 'precompile' => ['another command', 'npm install'] } }
+    let(:scripts_string) { { 'precompile' => 'npm install' } }
 
     context 'scripts section contains a key which has an array of commands' do
       it 'does not call key_string_contains_command' do
         expect(subject).not_to receive(:key_string_contains_command)
-        subject.key_contains_command(scripts_array, 'prebuild', 'npm')
+        subject.key_contains_command(scripts_array, 'precompile', 'npm')
       end
 
       it 'does call key_array_contains_command' do
         expect(subject).to receive(:key_array_contains_command)
-        subject.key_contains_command(scripts_array, 'prebuild', 'npm')
+        subject.key_contains_command(scripts_array, 'precompile', 'npm')
       end
     end
 
     context 'scripts section contains a key which is not an array' do
       it 'does call key_string_contains_command' do
         expect(subject).to receive(:key_string_contains_command)
-        subject.key_contains_command(scripts_string, 'prebuild', 'npm')
+        subject.key_contains_command(scripts_string, 'precompile', 'npm')
       end
 
       it 'does not call key_array_contains_command' do
         expect(subject).not_to receive(:key_array_contains_command)
-        subject.key_contains_command(scripts_string, 'prebuild', 'npm')
+        subject.key_contains_command(scripts_string, 'precompile', 'npm')
       end
     end
   end
 
   describe '#key_array_contains_command' do
-    let(:scripts_array_with_two_commands) { { 'prebuild' => ['another command && npm install'] } }
-    let(:scripts_array_with_two_commands2) { { 'prebuild' => ['npm install && another command'] } }
-    let(:scripts_array_with_other_commands) { { 'prebuild' => ['other command && another command'] } }
-    let(:scripts_array) { { 'prebuild' => ['another command', 'npm install'] } }
-    let(:scripts_array_with_other_command) { { 'prebuild' => ['other command'] } }
+    let(:scripts_array_with_two_commands) { { 'precompile' => ['another command && npm install'] } }
+    let(:scripts_array_with_two_commands2) { { 'precompile' => ['npm install && another command'] } }
+    let(:scripts_array_with_other_commands) { { 'precompile' => ['other command && another command'] } }
+    let(:scripts_array) { { 'precompile' => ['another command', 'npm install'] } }
+    let(:scripts_array_with_other_command) { { 'precompile' => ['other command'] } }
 
     context 'key contains two commands in the same string' do
       context 'one of the commands begins with the check_command' do
         it 'returns true' do
-          expect(subject.key_array_contains_command(scripts_array_with_two_commands, 'prebuild', 'npm')).to be_truthy
-          expect(subject.key_array_contains_command(scripts_array_with_two_commands2, 'prebuild', 'npm')).to be_truthy
+          expect(subject.key_array_contains_command(scripts_array_with_two_commands, 'precompile', 'npm')).to be_truthy
+          expect(subject.key_array_contains_command(scripts_array_with_two_commands2, 'precompile', 'npm')).to be_truthy
         end
       end
 
       context 'none of the commands begin with the check_command' do
         it 'returns false' do
-          expect(subject.key_array_contains_command(scripts_array_with_other_commands, 'prebuild', 'npm')).not_to be_truthy
+          expect(subject.key_array_contains_command(scripts_array_with_other_commands, 'precompile', 'npm')).not_to be_truthy
         end
       end
     end
@@ -92,36 +92,36 @@ describe AspNetCoreBuildpack::ScriptsParser do
     context 'key contains only one command in each string' do
       context 'one of the commands begins with the check_key' do
         it 'returns true' do
-          expect(subject.key_array_contains_command(scripts_array, 'prebuild', 'npm')).to be_truthy
+          expect(subject.key_array_contains_command(scripts_array, 'precompile', 'npm')).to be_truthy
         end
       end
 
       context 'none of the commands begin with the check_key' do
         it 'returns false' do
-          expect(subject.key_array_contains_command(scripts_array_with_other_command, 'prebuild', 'npm')).not_to be_truthy
+          expect(subject.key_array_contains_command(scripts_array_with_other_command, 'precompile', 'npm')).not_to be_truthy
         end
       end
     end
   end
 
   describe '#key_string_contains_command' do
-    let(:scripts_with_two_commands) { { 'prebuild' => 'another command && npm install' } }
-    let(:scripts_with_two_commands2) { { 'prebuild' => 'npm install && another command' } }
-    let(:scripts_with_other_commands) { { 'prebuild' => 'other command && another command' } }
-    let(:scripts) { { 'prebuild' => 'npm install' } }
-    let(:scripts_with_other_command) { { 'prebuild' => 'other command' } }
+    let(:scripts_with_two_commands) { { 'precompile' => 'another command && npm install' } }
+    let(:scripts_with_two_commands2) { { 'precompile' => 'npm install && another command' } }
+    let(:scripts_with_other_commands) { { 'precompile' => 'other command && another command' } }
+    let(:scripts) { { 'precompile' => 'npm install' } }
+    let(:scripts_with_other_command) { { 'precompile' => 'other command' } }
 
     context 'key contains two commands in the same string' do
       context 'one of the commands begins with the check_command' do
         it 'returns true' do
-          expect(subject.key_string_contains_command(scripts_with_two_commands, 'prebuild', 'npm')).to be_truthy
-          expect(subject.key_string_contains_command(scripts_with_two_commands2, 'prebuild', 'npm')).to be_truthy
+          expect(subject.key_string_contains_command(scripts_with_two_commands, 'precompile', 'npm')).to be_truthy
+          expect(subject.key_string_contains_command(scripts_with_two_commands2, 'precompile', 'npm')).to be_truthy
         end
       end
 
       context 'none of the commands begin with the check_command' do
         it 'returns false' do
-          expect(subject.key_string_contains_command(scripts_with_other_commands, 'prebuild', 'npm')).not_to be_truthy
+          expect(subject.key_string_contains_command(scripts_with_other_commands, 'precompile', 'npm')).not_to be_truthy
         end
       end
     end
@@ -129,13 +129,13 @@ describe AspNetCoreBuildpack::ScriptsParser do
     context 'key contains only one command in each string' do
       context 'the command begins with the check_key' do
         it 'returns true' do
-          expect(subject.key_string_contains_command(scripts, 'prebuild', 'npm')).to be_truthy
+          expect(subject.key_string_contains_command(scripts, 'precompile', 'npm')).to be_truthy
         end
       end
 
       context 'the command does not begin with the check_key' do
         it 'returns false' do
-          expect(subject.key_string_contains_command(scripts_with_other_command, 'prebuild', 'npm')).not_to be_truthy
+          expect(subject.key_string_contains_command(scripts_with_other_command, 'precompile', 'npm')).not_to be_truthy
         end
       end
     end
@@ -149,8 +149,8 @@ describe AspNetCoreBuildpack::ScriptsParser do
     context 'multiple project.json files exist' do
       before do
         FileUtils.mkdir_p(File.join(dir, 'src', 'project2'))
-        File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "prebuild":["other command", "another command"] }}') }
-        File.open(File.join(dir, 'src', 'project2', 'project.json'), 'w') { |f| f.write('{"scripts": { "prebuild":["npm install", "bower install"] }}') }
+        File.open(File.join(dir, 'src', 'project1', 'project.json'), 'w') { |f| f.write('{"scripts": { "precompile":["other command", "another command"] }}') }
+        File.open(File.join(dir, 'src', 'project2', 'project.json'), 'w') { |f| f.write('{"scripts": { "precompile":["npm install", "bower install"] }}') }
       end
 
       it 'calls get_scripts_section on each file' do
@@ -164,8 +164,8 @@ describe AspNetCoreBuildpack::ScriptsParser do
       end
 
       it 'calls key_contains_command on each scripts object' do
-        expect(subject).to receive(:key_contains_command).with({ 'prebuild' => ['other command', 'another command'] }, 'prebuild', 'npm')
-        expect(subject).to receive(:key_contains_command).with({ 'prebuild' => ['npm install', 'bower install'] }, 'prebuild', 'npm')
+        expect(subject).to receive(:key_contains_command).with({ 'precompile' => ['other command', 'another command'] }, 'precompile', 'npm')
+        expect(subject).to receive(:key_contains_command).with({ 'precompile' => ['npm install', 'bower install'] }, 'precompile', 'npm')
         subject.scripts_section_exists?(%w(npm))
       end
     end

--- a/lib/buildpack/compile/scripts_parser.rb
+++ b/lib/buildpack/compile/scripts_parser.rb
@@ -50,7 +50,7 @@ module AspNetCoreBuildpack
 
     def scripts_section_exists?(check_commands)
       return_value = false
-      check_keys = ['prebuild'.freeze, 'postbuild'.freeze, 'prerestore'.freeze, 'postrestore'.freeze]
+      check_keys = ['precompile'.freeze, 'postcompile'.freeze]
       Dir.glob(File.join(@build_dir, '**', 'project.json'.freeze)).each do |project_json|
         scripts = get_scripts_section(project_json)
         next unless scripts


### PR DESCRIPTION
Pre/Post build/restore keys do not currently work in .NET CLI, Pre/Post compile keys do work though.  Using the compile keys to test for npm and bower commands.