### PR TITLE
Fix dotnet core buildpack for 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ sudo: false
 language: ruby
 rvm:
   - "2.2.4"
+  - "2.3.1"
 gemfile:
   - cf.Gemfile

--- a/lib/buildpack/compile/installers/installer.rb
+++ b/lib/buildpack/compile/installers/installer.rb
@@ -21,7 +21,7 @@ module AspNetCoreBuildpack
     VERSION_FILE = 'VERSION'.freeze
 
     def self.descendants
-      ObjectSpace.each_object(Class).select { |subclass| subclass < self }
+      [BowerInstaller, DotnetInstaller, LibunwindInstaller, NodeJsInstaller]
     end
 
     def self.install_order


### PR DESCRIPTION
`AspNetCoreBuildpack::Installer#descendants` is not working as the buildpack expects for ruby `2.3.1`.
 
 Here, the release script tries to get all the descendants of the `AspNetCoreBuildpack::Installer` class: https://github.com/cloudfoundry-community/dotnet-core-buildpack/blob/7993ae7b46388cf49377e604bb7566ea1d34798a/lib/buildpack/release/releaser.rb#L38
 
 Instances of these Installer subclasses are then created here: https://github.com/cloudfoundry-community/dotnet-core-buildpack/blob/7993ae7b46388cf49377e604bb7566ea1d34798a/lib/buildpack/release/releaser.rb#L59
 
 I think the buildpack code expects that AspNetCoreBuildpack::Installer#descendants would return:
 
 ```
[AspNetCoreBuildpack::BowerInstaller,
 AspNetCoreBuildpack::NodeJsInstaller,
 AspNetCoreBuildpack::DotnetInstaller,
 AspNetCoreBuildpack::LibunwindInstaller]
 ```
 
 This is the actual behavior on ruby `2.2.4`.
 
 However, on ruby `2.3.1`, this is what is actually returned:
 
```
[9] pry(#<AspNetCoreBuildpack::Releaser>)> AspNetCoreBuildpack::Installer.descendants
=> [AspNetCoreBuildpack::BowerInstaller,
 AspNetCoreBuildpack::NodeJsInstaller,
 #<Class:#<AspNetCoreBuildpack::LibunwindInstaller:0x007fbeb18ae338>>,
 AspNetCoreBuildpack::DotnetInstaller,
 #<Class:#<AspNetCoreBuildpack::Installer:0x007fbeb1c644a0>>,
 AspNetCoreBuildpack::LibunwindInstaller,
 #<Class:#<AspNetCoreBuildpack::DotnetInstaller:0x007fbeb1c27280>>,
 #<Class:#<AspNetCoreBuildpack::DotnetInstaller:0x007fbeb1c34db8>>,
 #<Class:#<AspNetCoreBuildpack::LibunwindInstaller:0x007fbeb1c86d98>>,
 #<Class:#<AspNetCoreBuildpack::LibunwindInstaller:0x007fbeb1c8e660>>,
 #<Class:#<AspNetCoreBuildpack::NodeJsInstaller:0x007fbeb1cbef40>>,
 #<Class:#<AspNetCoreBuildpack::BowerInstaller:0x007fbeb51a9020>>]
```
 
 Anonymous singleton classes are returned by ObjectSpace.each_object as well. This is because of the following change/fix in ruby `2.3.1`: https://github.com/ruby/ruby/blob/ruby_2_3/ChangeLog#L7061-L7062
 
This PR fixes this by simply hardcoding the list of descendant subclasses rather than plucking it from the ObjectSpace. Installer subclasses are probably not going to be added at a high frequency, so I think the maintenance overhead of adding to this hardcoded list of constants is acceptable.

- Fixes #78